### PR TITLE
make sure kill the meteor.jar sprocess

### DIFF
--- a/pycocoevalcap/meteor/meteor.py
+++ b/pycocoevalcap/meteor/meteor.py
@@ -72,7 +72,7 @@ class Meteor:
         self.lock.release()
         return score
  
-    def __exit__(self):
+    def __del__(self):
         self.lock.acquire()
         self.meteor_p.stdin.close()
         self.meteor_p.kill()


### PR DESCRIPTION
Use \__del__ method to avoid [this](https://github.com/tylin/coco-caption/issues/14) issue
It seems that the \__exit__ method never been called.