### PR TITLE
bug fix: remove stray \r and \n in the SCORE commands in meteor stdin.

### DIFF
--- a/pycocoevalcap/meteor/meteor.py
+++ b/pycocoevalcap/meteor/meteor.py
@@ -52,6 +52,7 @@ class Meteor:
         # SCORE ||| reference 1 words ||| reference n words ||| hypothesis words
         hypothesis_str = hypothesis_str.replace('|||','').replace('  ',' ')
         score_line = ' ||| '.join(('SCORE', ' ||| '.join(reference_list), hypothesis_str))
+        score_line = score_line.replace('\n', '').replace('\r', '')
         self.meteor_p.stdin.write('{}\n'.format(score_line))
         return self.meteor_p.stdout.readline().strip()
 


### PR DESCRIPTION
This commit goes towards fixing https://github.com/tylin/coco-caption/issues/25 . Although there may be other cause of that issue as well.