### PR TITLE
bug fix: Remove the NUL character at the end to avoid JSONDecodeError

### DIFF
--- a/pycocoevalcap/spice/spice.py
+++ b/pycocoevalcap/spice/spice.py
@@ -70,8 +70,10 @@ class Spice:
             cwd=os.path.dirname(os.path.abspath(__file__)))
 
         # Read and process results
-        with open(out_file.name) as data_file:    
-          results = json.load(data_file)
+        # Remove the NUL character at the end to avoid JSONDecodeError
+        with open(out_file.name, 'r', encoding='utf-8') as data_file:
+            content = data_file.read().rstrip('\x00')        
+            results = json.loads(content)
         os.remove(in_file.name)
         os.remove(out_file.name)
 


### PR DESCRIPTION
Remove the NUL character at the end to avoid JSONDecodeError

the code before may cause the error below:

Traceback (most recent call last):
  File "/path/to/evaluate.py", line 65, in <module>
    eval_res = evaluate_metrics_from_lists(gen_captions, true_captions)
  File "/path/to/caption_evaluation_tools/eval_metrics.py", line 156, in evaluate_metrics_from_lists
    metrics, per_file_metrics = evaluate_metrics_from_files(
  File "/path/to/caption_evaluation_tools/eval_metrics.py", line 102, in evaluate_metrics_from_files
    cocoEval.evaluate()
  File "/path/to/caption_evaluation_tools/coco_caption/pycocoevalcap/eval.py", line 72, in evaluate
    score, scores = scorer.compute_score(gts, res)
  File "/path/to/caption_evaluation_tools/coco_caption/pycocoevalcap/spice/spice.py", line 79, in compute_score
    results = json.load(data_file)
  File "/path/to/miniconda3/envs/myenv/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/path/to/miniconda3/envs/myenv/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/path/to/miniconda3/envs/myenv/lib/python3.9/json/decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 71062 column 2 (char 1260980)


where the 'Extra data: line 71062 column 2' is actually a NUL symbol.